### PR TITLE
Add spinBoxValorEspecificado with default 'No establecido' state

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,6 +217,14 @@
                 </ul>
             </div>
         </section>
+        <hr class="m-0" />
+        <!-- SpinBox Valor Especificado -->
+        <section class="resume-section" id="valor-especificado">
+            <div class="resume-section-content">
+                <label for="spinBoxValorEspecificado">Asignar un valor especificado para 'sin datos' a las tablas de SALUD (opcional)</label>
+                <input type="number" id="spinBoxValorEspecificado" placeholder="No establecido" />
+            </div>
+        </section>
     </div>
     <!-- Bootstrap core JS-->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -31,4 +31,19 @@ window.addEventListener('DOMContentLoaded', event => {
         });
     });
 
+    // Configure spinBoxValorEspecificado
+    const spinBox = document.getElementById('spinBoxValorEspecificado');
+    if (spinBox) {
+        const defaultValue = -99999;
+        const showPlaceholder = () => {
+            if (spinBox.value === '0' || spinBox.value === '') {
+                spinBox.value = '';
+                spinBox.placeholder = 'No establecido';
+            }
+        };
+        showPlaceholder();
+        spinBox.addEventListener('input', showPlaceholder);
+        spinBox.getValue = () => spinBox.value === '' ? defaultValue : Number(spinBox.value);
+    }
+
 });


### PR DESCRIPTION
## Summary
- add a labeled numeric spin box for the optional SALUD tables value
- show "No establecido" when no value is entered and treat it as -99999

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aba86b9524832497ceea97eb1464fe